### PR TITLE
Add WASI platform guards alongside existing Windows guards

### DIFF
--- a/src/interpreter/config.c
+++ b/src/interpreter/config.c
@@ -40,9 +40,9 @@
 #include <stdarg.h>
 #include <unistd.h>
 #include <sys/types.h>
-#if !defined (__WIN32__)
+#if !defined(__WIN32__) && !defined(__wasi__)
 #include <pwd.h>
-#endif // !defined (__WIN32__)
+#endif // !defined(__WIN32__) && !defined(__wasi__)
 
 #include "../tools/tracelog.h"
 #include "config.h"
@@ -749,13 +749,13 @@ bool is_valid_libfizmo_config_key(char *key)
 
 char *get_user_homedir()
 {
-#if !defined (__WIN32__)
+#if !defined(__WIN32__) && !defined(__wasi__)
   struct passwd *pw_entry;
-#endif // !defined (__WIN32__)
+#endif // !defined(__WIN32__) && !defined(__wasi__)
 
   if (user_homedir_initialized == false)
   {
-#if !defined (__WIN32__)
+#if !defined(__WIN32__) && !defined(__wasi__)
     pw_entry = getpwuid(getuid());
     if (pw_entry->pw_dir == NULL)
       user_homedir = NULL;
@@ -764,7 +764,7 @@ char *get_user_homedir()
 #else
     if ((user_homedir = getenv("HOME")) == NULL)
       user_homedir = getenv("HOMEPATH");
-#endif // !defined (__WIN32__)
+#endif // !defined(__WIN32__) && !defined(__wasi__)
     user_homedir_initialized = true;
   }
 

--- a/src/interpreter/debugger.c
+++ b/src/interpreter/debugger.c
@@ -32,8 +32,10 @@
  */
 
 
-#ifndef debugger_c_INCLUDED 
+#ifndef debugger_c_INCLUDED
 #define debugger_c_INCLUDED
+
+#if !defined(__wasi__) && !defined(DISABLE_DEBUGGER)
 
 #define DEBUGGER_INPUT_BUFFER_SIZE 1024
 
@@ -341,6 +343,8 @@ void debugger_interpreter_stopped()
       free(elements[i]);
   }
 }
+
+#endif /* !defined(__wasi__) && !defined(DISABLE_DEBUGGER) */
 
 #endif /* debugger_c_INCLUDED */
 

--- a/src/interpreter/misc.c
+++ b/src/interpreter/misc.c
@@ -33,7 +33,9 @@
 
 
 #include <string.h>
+#if !defined(__wasi__)
 #include <signal.h>
+#endif
 #include <stdlib.h>
 #include <errno.h>
 
@@ -53,9 +55,9 @@
 #include "debugger.h"
 #endif // ENABLE_DEBUGGER
 
-#if !defined(__WIN32__)
+#if !defined(__WIN32__) && !defined(__wasi__)
 static struct sigaction fizmo_sigactions;
-#endif // defined(__WIN32__)
+#endif // !defined(__WIN32__) && !defined(__wasi__)
 
 
 void opcode_restart(void)
@@ -180,7 +182,7 @@ void abort_interpreter(int exit_code, z_ucs *error_message)
 }
 
 
-#if !defined(__WIN32__)
+#if !defined(__WIN32__) && !defined(__wasi__)
 static void catch_signal_and_abort(int sig_num)
 {
   TRACE_LOG("Caught signal %d.\n", sig_num);
@@ -191,12 +193,12 @@ static void catch_signal_and_abort(int sig_num)
       -1,
       (long)sig_num);
 }
-#endif // defined(__WIN32__)
+#endif // !defined(__WIN32__) && !defined(__wasi__)
 
 
 void init_signal_handlers(void)
 {
-#if !defined(__WIN32__)
+#if !defined(__WIN32__) && !defined(__wasi__)
   TRACE_LOG("Initialiazing signal handlers.\n");
 
   sigemptyset(&fizmo_sigactions.sa_mask);
@@ -209,13 +211,13 @@ void init_signal_handlers(void)
   sigaction(SIGQUIT, &fizmo_sigactions, NULL);
   sigaction(SIGBUS, &fizmo_sigactions, NULL);
   sigaction(SIGILL, &fizmo_sigactions, NULL);
-#endif // !defined(__WIN32__)
+#endif // !defined(__WIN32__) && !defined(__wasi__)
 }
 
 
 void deactivate_signal_handlers(void)
 {
-#if !defined(__WIN32__)
+#if !defined(__WIN32__) && !defined(__wasi__)
   TRACE_LOG("Deactivating signal handlers.\n");
 
   sigemptyset(&fizmo_sigactions.sa_mask);
@@ -228,6 +230,6 @@ void deactivate_signal_handlers(void)
   sigaction(SIGQUIT, &fizmo_sigactions, NULL);
   sigaction(SIGBUS, &fizmo_sigactions, NULL);
   sigaction(SIGILL, &fizmo_sigactions, NULL);
-#endif // !defined(__WIN32__)
+#endif // !defined(__WIN32__) && !defined(__wasi__)
 }
 


### PR DESCRIPTION
## Summary

- Add `&& !defined(__wasi__)` guards to the existing `__WIN32__` preprocessor conditionals
- Allows libfizmo to compile under [WASI](https://wasi.dev/) (WebAssembly System Interface) without external header shims or emulation flags
- 3 files changed, ~6 lines of logic change total

## Changes

**config.c** — Guard `#include <pwd.h>` and `getpwuid()`/`getuid()` calls. WASI uses the `getenv("HOME")` fallback path (same as Windows).

**misc.c** — Guard `#include <signal.h>` and `sigaction()` calls in signal handler setup/teardown. WASI doesn't support POSIX signals.

**debugger.c** — Wrap file body in `__wasi__`/`DISABLE_DEBUGGER` guard. The debugger uses sockets which are unavailable in WASI.

## Impact

Zero impact on existing platforms — the guards only activate when `__wasi__` is defined by the WASI toolchain. Follows the exact same `#if !defined()` pattern already used for `__WIN32__`.

## Context

This is being used in [wasiglk](https://github.com/bodar/wasiglk), which compiles IF interpreters (including fizmo) to WebAssembly using Zig's wasm32-wasi target. Previously this required 4 custom header shims to intercept POSIX includes — with these source-level guards, no external workarounds are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)